### PR TITLE
Auto convert/adapt relative css/less paths to absolute web-root relative paths

### DIFF
--- a/AutominPlugin.php
+++ b/AutominPlugin.php
@@ -61,6 +61,7 @@ class AutominPlugin extends BasePlugin
     return array(
          'autominEnabled' => array(AttributeType::Bool, 'default' => true),
          'autominCachingEnabled' => array(AttributeType::Bool, 'default' => true),
+         'autominAdaptCssPath' => array(AttributeType::Bool, 'default' => true),
          'autominMinifyEnabled' => array(AttributeType::Bool, 'default' => true),
          'autominPublicRoot' => array(AttributeType::String, 'default' => ''),
          'autominCachePath' => array(AttributeType::String, 'default' => ''),
@@ -75,6 +76,7 @@ class AutominPlugin extends BasePlugin
     $config_settings['autominEnabled'] = craft()->config->get('autominEnabled');
     $config_settings['autominCachingEnabled'] = craft()->config->get('autominCachingEnabled');
     $config_settings['autominMinifyEnabled'] = craft()->config->get('autominMinifyEnabled');
+    $config_settings['autominAdaptCssPath'] = craft()->config->get('autominAdaptCssPath');
     $config_settings['autominPublicRoot'] = craft()->config->get('autominPublicRoot');
     $config_settings['autominCachePath'] = craft()->config->get('autominCachePath');
     $config_settings['autominCacheURL'] = craft()->config->get('autominCacheURL');

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -73,6 +73,29 @@
 	</div>
 </div>
 
+<div class="field" id="autominAdaptCssPath-field">
+  <div class="heading">
+		<label for="autominAdaptCssPath">Adapt CSS Paths?</label>
+		<p class="instructions">When adaption is enabled, AutoMin will convert relative css paths to absolute ones.</p>
+	</div>
+	<div class="input">
+		<div class="select">
+    	<select id="autominAdaptCssPath" name="autominAdaptCssPath"{% if config_settings.autominAdaptCssPath is not null %} disabled="disabled"{% endif %}>
+        {% if config_settings.autominAdaptCssPath is null %}
+          <option value="1"{% if settings.autominAdaptCssPath %} selected{% endif %}>Yes</option>
+          <option value="0"{% if not settings.autominAdaptCssPath %} selected{% endif %}>No</option>
+        {% else %}
+          <option value="1"{% if config_settings.autominAdaptCssPath %} selected{% endif %}>Yes</option>
+          <option value="0"{% if not config_settings.autominAdaptCssPath %} selected{% endif %}>No</option>
+        {% endif %}
+     </select>
+    </div>
+    {% if config_settings.autominAdaptCssPath is not null %}
+      <p class="setting-is-disabled">This setting has been configured in the config file.</p>
+    {% endif %}      
+	</div>
+</div>
+
 <div class="field" id="autominPublicRoot-field">
   <div class="heading">
     <label for="autominPublicRoot">Public web root path</label>


### PR DESCRIPTION
I extended AutoMin to convert relative path's in .css and .less files automatically to absolute web-root relative paths.

The code worked in my test's but it would be great if someone could take a look if the code could be optimized.

e.g. I'm not fully satisfied with using a variable to pass the $file_server_path but I didn't know how to pass it as an argument in the callback. In PHP 5.4 this shouldn't be a problem (since I could just use $this-> instead of array($this,..) ) but since Craft requires PHP 5.3 this was the only solution I could come up with.

Also I'm not fully sure if the RegEx is "bullet-proof".

Hope the code is useful.
